### PR TITLE
SimpleCov設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# SimpleCovで生成されたファイルを除外
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ group :development, :test do
   # system test
   gem "capybara"
   gem "selenium-webdriver", "~> 4.29", ">= 4.29.1"
+
+  # カバレッジ計測
+  gem "simplecov"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.0)
+    docile (1.4.1)
     dotenv (3.1.7)
     drb (2.2.1)
     ed25519 (1.3.0)
@@ -316,6 +317,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     solid_cable (3.0.7)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -414,6 +421,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-rspec_rails
   selenium-webdriver (~> 4.29, >= 4.29.1)
+  simplecov
   solid_cable
   solid_cache
   solid_queue

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,4 +79,12 @@ RSpec.configure do |config|
   #
   # FactoryBotで省略記法を使うための設定
   config.include FactoryBot::Syntax::Methods
+  #
+  # SimpleCovの設定
+  if ENV["CIRCLE_ARTIFACTS"]
+    dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
+    SimpleCov.coverage_dir(dir)
+  end
+
+  SimpleCov.start
 end


### PR DESCRIPTION
## 前提

#6 を先に見てね

## やったこと

SimpleCovでカバレッジを見れるようにしました

RSpecのテスト結果に応じてカバレッジレポートが `coverage/`配下の`index.html`に出力されます

<img width="1718" alt="スクリーンショット 2025-03-04 22 15 25" src="https://github.com/user-attachments/assets/401a377f-d7d1-4020-8a37-82636a834b1c" />

↑の写真だとカバレッジが100%なのでわかりにくいですが、例えば`spec/system/product_spec.rb`で`describe "GET /products/:id/edit" do`のテストケースを丸々削除すると、`app/controllers/products_controller.rb`のカバレッジが88%に低下しているのが分かります

<img width="1709" alt="スクリーンショット 2025-03-04 22 14 00" src="https://github.com/user-attachments/assets/301eb9b4-f41d-4fa3-a31b-b3151582f611" />

ここで、`app/controllers/products_controller.rb`をクリックするとカバレッジが満たせていない行が赤で表示されます

<img width="1634" alt="スクリーンショット 2025-03-04 22 14 20" src="https://github.com/user-attachments/assets/19ab5fe2-babe-493e-afde-aacc51138884" />


今後は、PRを投げる前に自身の実装箇所でカバレッジが満たせていない行がないかどうかを確認するのがよさそうです

## レビュワーに確認して欲しいこと

- [ ] `bundle exec rspec`を実行後に`coverage/index.html`からカバレッジレポートが確認できること
